### PR TITLE
Implement deterministic RNG

### DIFF
--- a/src/rng.js
+++ b/src/rng.js
@@ -1,3 +1,90 @@
-export function rng() {
-  return Math.random();
+/**
+ * Simple deterministic pseudo random number generator based on xorshift32.
+ *
+ * @param {string|number} seed
+ * @returns {import('./types').RNG}
+ */
+export function createRNG(seed) {
+  let s;
+  if (typeof seed === 'string') {
+    s = hashString(seed);
+  } else {
+    s = Number(seed) || 0;
+  }
+
+  s = normalizeSeed(s);
+
+  let state = s;
+
+  /**
+   * Generate the next random float between 0 (inclusive) and 1 (exclusive).
+   * @returns {number}
+   */
+  function next() {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0) / 4294967296;
+  }
+
+  return {
+    next,
+    float: next,
+    int(min, max) {
+      if (typeof min !== 'number') min = 0;
+      if (typeof max !== 'number') max = 0;
+
+      min = Math.floor(min);
+      max = Math.floor(max);
+
+      if (min > max) {
+        const tmp = min;
+        min = max;
+        max = tmp;
+      }
+
+      return Math.floor(next() * (max - min)) + min;
+    },
+    pickWeighted(list) {
+      let total = 0;
+      for (const item of list || []) {
+        const w = typeof item.weight === 'number' && item.weight > 0 ? item.weight : 0;
+        total += w;
+      }
+      if (total <= 0) return undefined;
+      let r = next() * total;
+      for (const item of list) {
+        const w = typeof item.weight === 'number' && item.weight > 0 ? item.weight : 0;
+        if (r < w) return item;
+        r -= w;
+      }
+      return list[list.length - 1];
+    },
+  };
 }
+
+/**
+ * Convert any numeric value to an unsigned 32bit integer.
+ * @param {number} n
+ * @returns {number}
+ */
+function normalizeSeed(n) {
+  n = Math.floor(n);
+  n %= 4294967296; // 2^32
+  if (n < 0) n += 4294967296;
+  return n >>> 0;
+}
+
+/**
+ * Very small string hash to convert a string to a 32bit seed.
+ * @param {string} str
+ * @returns {number}
+ */
+function hashString(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(31, h) + str.charCodeAt(i) | 0;
+  }
+  return normalizeSeed(h);
+}
+

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,1 +1,13 @@
 export type Placeholder = unknown;
+
+export interface WeightedItem {
+  weight: number;
+  [key: string]: unknown;
+}
+
+export interface RNG {
+  next(): number;
+  float(): number;
+  int(min: number, max: number): number;
+  pickWeighted<T extends WeightedItem>(list: T[]): T | undefined;
+}


### PR DESCRIPTION
## Summary
- add createRNG function with xorshift32-based deterministic PRNG and weighted picking
- define RNG and WeightedItem type definitions

## Testing
- `node -e "import('./src/rng.js').then(m=>{const r1=m.createRNG('test');const r2=m.createRNG('test');console.log(r1.next(),r2.next());console.log(r1.int(0,10),r2.int(0,10));console.log(r1.pickWeighted([{weight:1,val:'a'},{weight:2,val:'b'}]));});"`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d207dfdc832a9641da1cf721d506