### PR TITLE
Populate starter game data

### DIFF
--- a/data/affixes.json
+++ b/data/affixes.json
@@ -1,1 +1,17 @@
-[]
+{
+  "affixes": [
+    {
+      "id": "speed",
+      "mods": {"move_speed_pct": 30, "attack_speed_pct": 20}
+    },
+    {"id": "strong", "mods": {"dps_mult": 1.25, "knockback_chance": 10}},
+    {"id": "extra_fast", "mods": {"move_speed_pct": 60}},
+    {"id": "stone_skin", "mods": {"def_mult": 1.5, "kinetic_res_add": 30}},
+    {"id": "mana_burn", "mods": {"mana_burn_on_hit": 10}},
+    {
+      "id": "spectral_hit",
+      "mods": {"elemental_bonus": ["laser", "plasma", "ion"], "bonus_pct": 25}
+    },
+    {"id": "cursed", "mods": {"cast_on_engage": "curse_weaken"}}
+  ]
+}

--- a/data/difficulties.json
+++ b/data/difficulties.json
@@ -1,1 +1,44 @@
-[]
+{
+  "difficulties": [
+    {
+      "id": "normal",
+      "hp_mult": 1.0,
+      "dmg_mult": 1.0,
+      "def_mult": 1.0,
+      "res_bonus": {"laser": 0, "plasma": 0, "ion": 0, "kinetic": 0},
+      "affix_pool": ["speed", "strong", "cursed", "mana_burn"]
+    },
+    {
+      "id": "nightmare",
+      "hp_mult": 2.0,
+      "dmg_mult": 1.6,
+      "def_mult": 1.5,
+      "res_bonus": {"laser": 20, "plasma": 20, "ion": 20, "kinetic": 10},
+      "affix_pool": [
+        "speed",
+        "strong",
+        "cursed",
+        "mana_burn",
+        "extra_fast",
+        "stone_skin"
+      ]
+    },
+    {
+      "id": "hell",
+      "hp_mult": 3.2,
+      "dmg_mult": 2.3,
+      "def_mult": 2.4,
+      "res_bonus": {"laser": 50, "plasma": 50, "ion": 50, "kinetic": 25},
+      "affix_pool": [
+        "speed",
+        "strong",
+        "cursed",
+        "mana_burn",
+        "extra_fast",
+        "stone_skin",
+        "spectral_hit"
+      ]
+    }
+  ]
+}
+

--- a/data/lootTables.json
+++ b/data/lootTables.json
@@ -1,1 +1,24 @@
-[]
+{
+  "loot_tables": [
+    {
+      "id": "common_creep",
+      "rolls": 1,
+      "entries": [
+        {"group": "credits", "weight": 60, "amount": [8, 20]},
+        {"group": "battery", "weight": 25, "quality": ["minor", "normal"]},
+        {"group": "component_white", "weight": 12},
+        {"group": "component_blue", "weight": 3}
+      ]
+    },
+    {
+      "id": "elite_creep",
+      "rolls": 2,
+      "entries": [
+        {"group": "credits", "weight": 40, "amount": [20, 60]},
+        {"group": "component_blue", "weight": 45},
+        {"group": "component_yellow", "weight": 12},
+        {"group": "named_token", "weight": 3}
+      ]
+    }
+  ]
+}

--- a/data/monsters.json
+++ b/data/monsters.json
@@ -1,1 +1,72 @@
-[]
+{
+  "monsters": [
+    {
+      "id": "scavenger_drone",
+      "role": "melee_swarm",
+      "base_level_offset": 0,
+      "base_hp": 18,
+      "base_dps": 3,
+      "base_def": 6,
+      "base_res": {"laser": 0, "plasma": 0, "ion": 0, "kinetic": 0},
+      "ai": {"type": "pack_ai", "aggro_radius": 10}
+    },
+    {
+      "id": "rust_raider",
+      "role": "slow_tank",
+      "base_level_offset": 0,
+      "base_hp": 35,
+      "base_dps": 2,
+      "base_def": 10,
+      "base_res": {"kinetic": 20, "ion": 0, "laser": 0, "plasma": 0},
+      "ai": {"type": "slow_melee", "aggro_radius": 8}
+    },
+    {
+      "id": "needle_turret",
+      "role": "ranged_pester",
+      "base_level_offset": 0,
+      "base_hp": 12,
+      "base_dps": 4,
+      "base_def": 4,
+      "base_res": {"laser": 0, "plasma": 0, "ion": 0, "kinetic": 0},
+      "ai": {
+        "type": "kiting_ranged",
+        "aggro_radius": 12,
+        "keep_distance": 6
+      }
+    },
+    {
+      "id": "void_knight",
+      "role": "caster_support",
+      "base_level_offset": 1,
+      "base_hp": 120,
+      "base_dps": 18,
+      "base_def": 80,
+      "base_res": {"laser": 0, "plasma": 0, "ion": 20, "kinetic": 0},
+      "ai": {
+        "type": "caster",
+        "aggro_radius": 18,
+        "uses_curses": true
+      }
+    },
+    {
+      "id": "doom_cruiser",
+      "role": "bruiser",
+      "base_level_offset": 1,
+      "base_hp": 160,
+      "base_dps": 22,
+      "base_def": 90,
+      "base_res": {"laser": 10, "plasma": 0, "ion": 0, "kinetic": 10},
+      "ai": {"type": "aggressive", "aggro_radius": 16}
+    },
+    {
+      "id": "venom_wyrm",
+      "role": "glass_cannon",
+      "base_level_offset": 2,
+      "base_hp": 80,
+      "base_dps": 30,
+      "base_def": 40,
+      "base_res": {"laser": 0, "plasma": 25, "ion": 0, "kinetic": 0},
+      "ai": {"type": "hit_and_run", "aggro_radius": 14}
+    }
+  ]
+}

--- a/data/tiers.json
+++ b/data/tiers.json
@@ -1,1 +1,43 @@
-[]
+{
+  "tiers": [
+    {
+      "id": "normal",
+      "level_bonus": 0,
+      "hp_mult": 1.0,
+      "dps_mult": 1.0,
+      "def_mult": 1.0,
+      "affix_count": [0, 0]
+    },
+    {
+      "id": "champion",
+      "level_bonus": 2,
+      "hp_mult": 2.0,
+      "dps_mult": 1.2,
+      "def_mult": 1.2,
+      "affix_count": [1, 1]
+    },
+    {
+      "id": "unique",
+      "level_bonus": 3,
+      "hp_mult": 3.5,
+      "dps_mult": 1.5,
+      "def_mult": 1.5,
+      "affix_count": [2, 3],
+      "minions": {
+        "count_range": [3, 6],
+        "level_bonus": 1,
+        "hp_mult": 1.5,
+        "dps_mult": 1.2,
+        "def_mult": 1.2
+      }
+    },
+    {
+      "id": "boss",
+      "level_bonus": 5,
+      "hp_mult": 10.0,
+      "dps_mult": 2.0,
+      "def_mult": 2.0,
+      "affix_count": [2, 4]
+    }
+  ]
+}

--- a/data/zones.json
+++ b/data/zones.json
@@ -1,1 +1,32 @@
-[]
+{
+  "zones": [
+    {
+      "id": "outer_rim",
+      "name": "Outer Rim",
+      "level_range": {
+        "normal": [1, 3],
+        "nightmare": [36, 39],
+        "hell": [67, 70]
+      },
+      "spawn_table": [
+        {"monster_id": "scavenger_drone", "weight": 5},
+        {"monster_id": "rust_raider", "weight": 3},
+        {"monster_id": "needle_turret", "weight": 2}
+      ]
+    },
+    {
+      "id": "chaos_nebula",
+      "name": "Chaos Nebula",
+      "level_range": {
+        "normal": [26, 28],
+        "nightmare": [55, 58],
+        "hell": [84, 85]
+      },
+      "spawn_table": [
+        {"monster_id": "void_knight", "weight": 4},
+        {"monster_id": "doom_cruiser", "weight": 4},
+        {"monster_id": "venom_wyrm", "weight": 2}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- fill `data/difficulties.json` with normal, nightmare, and hell difficulty stats
- add zone definitions for Outer Rim and Chaos Nebula
- supply starter monsters, tiers, affixes, and loot tables

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d5048840832aa20840f6dccbec35