### PR TITLE
feat: add spawn tester ui

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,12 @@
 
     .hud-hint{position:fixed; bottom:12px; left:12px; font-size:12px; color:#a8eaff; text-shadow:0 0 8px #0ff8}
     .top-right{position:fixed; top:10px; right:12px; font-size:12px; color:#aaf; text-shadow:0 0 8px #0ff8}
+
+    /* minimal spawn tester ui */
+    #controls{margin:8px;display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+    #controls label{margin-right:4px}
+    #status{margin:8px}
+    #out{margin:8px;padding:8px;max-height:240px;overflow:auto;border:1px solid #0ff4;background:#0004}
   </style>
 </head>
 <body>
@@ -72,6 +78,16 @@
 
     <div class="hud-hint">← → ↑ ↓: Bewegen (auch Zielen) • Leertaste: Feuer • Q/E: Plasma/Cluster • R: Singularität • G: Drohnen-Überladung • Z: Shutdown • K: Skillbaum • P: Pause • M: Mute</div>
     <div class="top-right" id="info"></div>
+
+    <div id="controls">
+      <label>Zone <select id="zone"></select></label>
+      <label>Difficulty <select id="difficulty"></select></label>
+      <label>Seed <input id="seed" value="demo"></label>
+      <button id="spawn">Spawn Pack</button>
+      <button id="spawnToWorld">Spawn To World</button>
+    </div>
+    <div id="status"></div>
+    <pre id="out"></pre>
   </div>
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,78 @@
-import { initLegacyGame } from './legacy/game.js';
+import { loadAllData } from './dataLoader.js';
+import { spawnPack } from './spawn.js';
+import { initLegacyGame, addUnitsToWorld } from './legacy/game.js';
 
 const rootEl = document.getElementById('app');
 initLegacyGame(rootEl);
+
+let lastSpawn = null;
+
+function setStatus(msg, isError = false) {
+  const el = document.getElementById('status');
+  if (el) {
+    el.textContent = msg;
+    el.style.color = isError ? 'red' : '';
+  }
+}
+
+async function main() {
+  let data;
+  try {
+    data = await loadAllData();
+  } catch (err) {
+    setStatus(`Fehler beim Laden: ${err.message}`, true);
+    return;
+  }
+
+  const zoneSel = document.getElementById('zone');
+  const diffSel = document.getElementById('difficulty');
+  data.zones.forEach((z) => {
+    const opt = document.createElement('option');
+    opt.value = z.id;
+    opt.textContent = z.name;
+    zoneSel.appendChild(opt);
+  });
+  data.difficulties.forEach((d) => {
+    const opt = document.createElement('option');
+    opt.value = d.id;
+    opt.textContent = d.id;
+    diffSel.appendChild(opt);
+  });
+
+  const seedInput = document.getElementById('seed');
+  const spawnBtn = document.getElementById('spawn');
+  const spawnWorldBtn = document.getElementById('spawnToWorld');
+  const outEl = document.getElementById('out');
+
+  spawnBtn.addEventListener('click', async () => {
+    spawnBtn.disabled = true;
+    spawnWorldBtn.disabled = true;
+    const zoneId = zoneSel.value;
+    const difficulty = diffSel.value;
+    const seed = seedInput.value;
+    const t0 = performance.now();
+    try {
+      const res = await spawnPack({ zoneId, difficulty, seed });
+      lastSpawn = Array.isArray(res) ? res : res.pack;
+      outEl.textContent = JSON.stringify(res, null, 2);
+      const zoneLevel = res.zoneLevel ?? 'N/A';
+      const ms = Math.round(performance.now() - t0);
+      setStatus(`Spawn OK • ZoneLevel=${zoneLevel} • Seed="${seed}" • ${ms}ms`);
+    } catch (err) {
+      setStatus(err.message, true);
+    } finally {
+      spawnBtn.disabled = false;
+      spawnWorldBtn.disabled = false;
+    }
+  });
+
+  spawnWorldBtn.addEventListener('click', () => {
+    if (lastSpawn) {
+      addUnitsToWorld(lastSpawn);
+    } else {
+      setStatus("Bitte zuerst 'Spawn Pack' ausführen.");
+    }
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary
- add minimal spawn tester controls to HTML
- load data and spawn packs via new UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896db718010832a94909cd38fedb0f1