### PR TITLE
feat(mobile): add on-screen joystick and hook mobile input into game loop

### DIFF
--- a/src/legacy/game.js
+++ b/src/legacy/game.js
@@ -120,15 +120,16 @@ class Player{
     this.hpMax=120; this.hp=this.hpMax; this.shieldMax=80; this.shield=this.shieldMax; this.shieldRegen=10; this.shieldCD=0; this.base={hpMax:this.hpMax, shieldMax:this.shieldMax, speed:this.speed}; // seconds until regen starts
   }
   update(dt, game){
-    let dx=0,dy=0;
-    if(Input.isDown('ArrowLeft')) dx-=1;
-    if(Input.isDown('ArrowRight')) dx+=1;
-    if(Input.isDown('ArrowUp')) dy-=1;
-    if(Input.isDown('ArrowDown')) dy+=1;
+    let dx = mobileInput.x;
+    let dy = -mobileInput.y;
+    if(Input.isDown('ArrowLeft')) dx -= 1;
+    if(Input.isDown('ArrowRight')) dx += 1;
+    if(Input.isDown('ArrowUp')) dy -= 1;
+    if(Input.isDown('ArrowDown')) dy += 1;
     const len = Math.hypot(dx,dy);
+    if(len > 1){ dx /= len; dy /= len; }
     if(len>0.0001){ this.aim = Math.atan2(dy, dx); }
-    const denom = len || 1;
-    this.x += (dx/denom)*this.speed*dt; this.y += (dy/denom)*this.speed*dt; this.x=clamp(this.x,20,WORLD_W-20); this.y=clamp(this.y,20,WORLD_H-20);
+    this.x += dx*this.speed*dt; this.y += dy*this.speed*dt; this.x=clamp(this.x,20,WORLD_W-20); this.y=clamp(this.y,20,WORLD_H-20);
     
     // Regen shield if not recently hit
     if(this.shield< this.shieldMax){ if(this.shieldCD>0) this.shieldCD-=dt; else this.shield = clamp(this.shield + this.shieldRegen*dt, 0, this.shieldMax); }
@@ -537,6 +538,12 @@ export function fitCanvasToScreen(canvas) {
   const ctx = canvas.getContext('2d');
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0); // Zeichnen in CSS-Pixeln
   return { dpr, w, h, ctx };
+}
+
+let mobileInput = {x:0,y:0};
+/** Von main.js aufgerufen */
+export function setMobileInputVector(v){
+  mobileInput = v || {x:0,y:0};
 }
 
 /** @typedef {import('../types').UnitInstance} UnitInstance */

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,16 @@
 import { loadAllData } from './dataLoader.js';
 import { spawnPack } from './spawn.js';
-import { initLegacyGame, addUnitsToWorld, getWorldSummary, fitCanvasToScreen } from './legacy/game.js';
+import { initLegacyGame, addUnitsToWorld, getWorldSummary, fitCanvasToScreen, setMobileInputVector } from './legacy/game.js';
+import { createJoystick } from './mobileJoystick.js';
 
 const rootEl = document.getElementById('app');
 initLegacyGame(rootEl);
+
+let joystick = null;
+function initMobileControls(){
+  if (!joystick) joystick = createJoystick(document.body);
+}
+initMobileControls();
 
 const canvas = document.querySelector('#view');
 function onResize(){ fitCanvasToScreen(canvas); }
@@ -15,6 +22,13 @@ canvas.addEventListener('pointerdown', e => { e.preventDefault(); /* start handl
 canvas.addEventListener('pointermove', e => { e.preventDefault(); /* move handling */ });
 canvas.addEventListener('pointerup', e => { /* end handling */ });
 canvas.addEventListener('pointercancel', e => { /* cancel handling */ });
+
+function gameTick(){
+  const v = joystick ? joystick.get() : {x:0,y:0};
+  setMobileInputVector(v);
+  requestAnimationFrame(gameTick);
+}
+requestAnimationFrame(gameTick);
 
 let lastSpawn = null;
 

--- a/src/mobileJoystick.js
+++ b/src/mobileJoystick.js
@@ -1,0 +1,80 @@
+export function createJoystick(rootEl = document.body) {
+  const base = document.createElement('div');
+  const knob = document.createElement('div');
+
+  Object.assign(base.style, {
+    position:'fixed', left:'20px',
+    bottom:'calc(20px + env(safe-area-inset-bottom))',
+    width:'120px', height:'120px',
+    borderRadius:'60px',
+    background:'rgba(255,255,255,0.08)',
+    backdropFilter:'blur(2px)',
+    zIndex:20, touchAction:'none', userSelect:'none'
+  });
+  Object.assign(knob.style, {
+    position:'absolute', left:'50%', top:'50%',
+    width:'56px', height:'56px',
+    marginLeft:'-28px', marginTop:'-28px',
+    borderRadius:'28px',
+    background:'rgba(255,255,255,0.25)',
+    boxShadow:'0 0 8px rgba(0,0,0,0.35)'
+  });
+  base.appendChild(knob);
+  rootEl.appendChild(base);
+
+  const radius = 50;
+  let active = false;
+  let center = {x:0,y:0};
+  let value  = {x:0,y:0};
+
+  const clamp = (v,m)=>Math.max(-m, Math.min(m, v));
+  const setKnob = (dx,dy)=>{ knob.style.transform = `translate(${dx}px, ${dy}px)`; };
+
+  function getPoint(e){
+    if (e.touches && e.touches[0]) return e.touches[0];
+    return e;
+  }
+
+  function start(e){
+    active = true;
+    const r = base.getBoundingClientRect();
+    center = { x: r.left + r.width/2, y: r.top + r.height/2 };
+    move(e);
+  }
+
+  function move(e){
+    if(!active) return;
+    const p = getPoint(e);
+    const dx = clamp(p.clientX - center.x, radius);
+    const dy = clamp(p.clientY - center.y, radius);
+    setKnob(dx, dy);
+    value = { x: +(dx / radius).toFixed(3), y: +(-dy / radius).toFixed(3) };
+    if (e.cancelable) e.preventDefault();
+  }
+
+  function end(){
+    active = false;
+    value = {x:0,y:0};
+    setKnob(0,0);
+  }
+
+  base.addEventListener('pointerdown', start, { passive:false });
+  window.addEventListener('pointermove', move, { passive:false });
+  window.addEventListener('pointerup', end, { passive:true });
+  window.addEventListener('pointercancel', end, { passive:true });
+
+  // Touch-Fallback (ältere iOS-Versionen)
+  base.addEventListener('touchstart', start, { passive:false });
+  window.addEventListener('touchmove',   move, { passive:false });
+  window.addEventListener('touchend',    end,  { passive:true });
+  window.addEventListener('touchcancel', end,  { passive:true });
+
+  return {
+    /** Gibt Vektor {x,y} in [-1..1] zurück. y>0 = nach oben/vorwärts */
+    get(){ return value; },
+    /** Optional: Position/Farbe anpassen */
+    setStyle(s){ Object.assign(base.style, s.base||{}); Object.assign(knob.style, s.knob||{}); },
+    /** Entfernen */
+    destroy(){ base.remove(); window.removeEventListener('pointermove', move); }
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable mobile joystick overlay for touch devices
- forward joystick vector to legacy game loop
- support joystick movement inside player update

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6896e54f35ec832a907fc335673891f2