### PR TITLE
ci: add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Optional: Base-Path fix für Unterordner-Repos
+      - name: Inject base path (optional)
+        if: ${{ always() }}
+        run: |
+          REPO="${{ github.event.repository.name }}"
+          # Nur wenn index.html existiert und kein <base> Tag gesetzt ist:
+          if [ -f "index.html" ] && ! grep -qi "<base " index.html; then
+            sed -i 's#<head>#<head><base href="/'"$REPO"'/">#' index.html || true
+          fi
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Dieses Projekt demonstriert eine modulare Spawn-Pipeline für eine ARPG-artige S
 - `index.html` mit einem lokalen HTTP-Server öffnen.
 - In VS Code: Erweiterung **Live Server** installieren, `index.html` rechtsklicken → "Open with Live Server".
 
+## GitHub Pages
+- Nach dem ersten erfolgreichen Run ist die Seite hier erreichbar:
+  https://<USER>.github.io/<REPO>/
+- Bei 404: 1–2 Minuten warten oder Pages in Settings prüfen.
+- Wenn Assets nicht laden: <base>-Tag prüfen (siehe Workflow-Schritt "Inject base path").
+
 ## Datenformate (Kurzreferenz)
 - `difficulties.json`: `hp_mult`, `dmg_mult`, `def_mult`, `res_bonus`, `affix_pool`
 - `zones.json`: `level_range` je Difficulty, `spawn_table`, optionale `tier_probs`, `difficulty_multipliers`


### PR DESCRIPTION
## Summary
- add GitHub Pages deployment workflow with optional base path injection
- document Pages URL and troubleshooting in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896e6f54d80832a878633420dd07153