### PR TITLE
fix(mobile): safe-area & visualViewport sizing, no-zoom inputs, non-scrollable canvas, responsive controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,12 @@
       --neon-lime:#00ff85;
       --neon-yellow:#ffd400;
       --hud:#00e5ff;
+      --gap:8px;
     }
     *{box-sizing:border-box}
-    html,body{margin:0;padding:0;height:100%;background:#000;overscroll-behavior:none;color:#cfe9ff;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Inter,Arial;overflow:hidden}
-    #app{position:fixed;inset:0;padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left)}
+    html,body{margin:0;padding:0;height:100%;background:#000;overscroll-behavior:none;}
+    body{overflow:hidden;color:#cfe9ff;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Inter,Arial;-webkit-touch-callout:none;-webkit-user-select:none;-webkit-text-size-adjust:100%;}
+    #app{position:fixed;inset:0;padding:env(safe-area-inset-top) env(safe-area-inset-right) calc(env(safe-area-inset-bottom)) env(safe-area-inset-left)}
     #wrap{position:fixed;inset:0;display:grid;place-items:center}
     canvas{display:block;touch-action:none}
     canvas#view{image-rendering:pixelated;background:#000;box-shadow:0 0 40px #05f4, 0 0 120px #0af2 inset;border:1px solid #0af7;border-radius:12px}
@@ -38,11 +40,27 @@
     .top-right{position:fixed; top:10px; right:12px; font-size:12px; color:#aaf; text-shadow:0 0 8px #0ff8}
 
     /* minimal spawn tester ui */
-    #controls{position:fixed;left:0;right:0;bottom:calc(8px + env(safe-area-inset-bottom));display:flex;gap:8px;justify-content:center;z-index:10;flex-wrap:wrap;align-items:center}
+    #controls{
+      position:fixed;left:0;right:0;
+      bottom:calc(var(--gap) + env(safe-area-inset-bottom));
+      display:flex;gap:var(--gap);justify-content:center;flex-wrap:wrap;
+      z-index:10;
+    }
     #controls label{margin-right:4px}
-    #status{margin-top:8px}
+    #controls select,#controls input,#controls button{
+      font-size:16px;line-height:1.2;padding:6px 10px;border-radius:10px;
+    }
+    #status{position:fixed;left:var(--gap);right:var(--gap);bottom:calc(56px + env(safe-area-inset-bottom));z-index:10;color:#9cf;}
     #status.error{color:red}
+    .desktop-only{display:block;}
+    .mobile-only{display:none;}
     #out{margin:8px;padding:8px;max-height:240px;overflow:auto;border:1px solid #0ff4;background:#0004}
+
+    @media (max-width: 600px){
+      #controls{gap:6px;}
+      #legend,.desktop-only{display:none;}
+      .mobile-only{display:block;}
+    }
   </style>
 </head>
 <body>
@@ -81,12 +99,12 @@
       </div>
     </div>
 
-    <div class="hud-hint">← → ↑ ↓: Bewegen (auch Zielen) • Leertaste: Feuer • Q/E: Plasma/Cluster • R: Singularität • G: Drohnen-Überladung • Z: Shutdown • K: Skillbaum • P: Pause • M: Mute</div>
+    <div id="legend" class="hud-hint desktop-only">← → ↑ ↓: Bewegen (auch Zielen) • Leertaste: Feuer • Q/E: Plasma/Cluster • R: Singularität • G: Drohnen-Überladung • Z: Shutdown • K: Skillbaum • P: Pause • M: Mute</div>
     <div class="top-right" id="info"></div>
 
     <div id="controls">
-      <label>Zone <select id="zone"></select></label>
-      <label>Difficulty <select id="difficulty"></select></label>
+      <label>Zone <select id="zone" style="min-width:110px"></select></label>
+      <label>Diff. <select id="difficulty" style="min-width:110px"></select></label>
       <label>Seed <input id="seed" value="demo"></label>
       <button id="spawn">Spawn Pack</button>
       <button id="spawnToWorld">Spawn To World</button>

--- a/src/legacy/game.js
+++ b/src/legacy/game.js
@@ -528,15 +528,16 @@ requestAnimationFrame(loop);
 }
 
 export function fitCanvasToScreen(canvas) {
-  const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 3)); // DPR begrenzen für iPhone
-  const w = Math.floor(window.innerWidth);
-  const h = Math.floor(window.innerHeight);
+  const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 3));
+  const vv = window.visualViewport;
+  const w = Math.floor(vv?.width ?? window.innerWidth);
+  const h = Math.floor(vv?.height ?? window.innerHeight);
   canvas.style.width = w + 'px';
   canvas.style.height = h + 'px';
   canvas.width  = Math.floor(w * dpr);
   canvas.height = Math.floor(h * dpr);
   const ctx = canvas.getContext('2d');
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0); // Zeichnen in CSS-Pixeln
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   return { dpr, w, h, ctx };
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -12,16 +12,17 @@ function initMobileControls(){
 }
 initMobileControls();
 
-const canvas = document.querySelector('#view');
-function onResize(){ fitCanvasToScreen(canvas); }
-window.addEventListener('resize', onResize, { passive:true });
-onResize();
+const canvas = document.querySelector('canvas');
+function applySizing(){ fitCanvasToScreen(canvas); }
+window.addEventListener('resize', applySizing, { passive:true });
+if (window.visualViewport) {
+  window.visualViewport.addEventListener('resize', applySizing, { passive:true });
+}
+applySizing();
 
-// Pointer-Events statt separater Mouse/Touch:
-canvas.addEventListener('pointerdown', e => { e.preventDefault(); /* start handling */ });
-canvas.addEventListener('pointermove', e => { e.preventDefault(); /* move handling */ });
-canvas.addEventListener('pointerup', e => { /* end handling */ });
-canvas.addEventListener('pointercancel', e => { /* cancel handling */ });
+['pointerdown','pointermove','wheel','touchstart','touchmove'].forEach(t => {
+  canvas.addEventListener(t, e => { if (e.cancelable) e.preventDefault(); }, { passive:false });
+});
 
 function gameTick(){
   const v = joystick ? joystick.get() : {x:0,y:0};


### PR DESCRIPTION
## Summary
- ensure layout respects safe areas, disables iOS zoom on inputs and hides long legend on mobile
- resize canvas using `visualViewport` for accurate DPR scaling
- block default scrolling on canvas interactions and handle viewport resize events

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896eab3bc1c832a9d573718c665b23e